### PR TITLE
Added support for zone temperature offsets using VirtTempOffsetHeat

### DIFF
--- a/custom_components/ariston/__init__.py
+++ b/custom_components/ariston/__init__.py
@@ -55,7 +55,7 @@ SET_ITEM_BY_ID_SCHEMA = vol.Schema(
         vol.Required(ATTR_DEVICE_ID): cv.string,
         vol.Required(ATTR_ITEM_ID): cv.string,
         vol.Required(ATTR_ZONE): cv.positive_int,
-        vol.Required(ATTR_VALUE): cv.positive_float,
+        vol.Required(ATTR_VALUE): vol.Coerce(float),
     }
 )
 

--- a/custom_components/ariston/ariston.py
+++ b/custom_components/ariston/ariston.py
@@ -208,6 +208,7 @@ class ThermostatProperties:
     ZONE_HEAT_REQUEST: final = "ZoneHeatRequest"
     ZONE_ECONOMY_TEMP: final = "ZoneEconomyTemp"
     ZONE_DEROGA: final = "ZoneDeroga"
+    ZONE_VIRT_TEMP_OFFSET_HEAT: final = "VirtTempOffsetHeat"
 
 
 class ConsumptionProperties:

--- a/custom_components/ariston/services.yaml
+++ b/custom_components/ariston/services.yaml
@@ -43,6 +43,7 @@ set_item_by_id:
             - "ZoneEconomyTemp"
             - "ZoneMode"
             - "ZoneDeroga"
+            - "VirtTempOffsetHeat"
     zone:
       name: Thermostat zone
       description: Number of the zone. Set 0 if device.


### PR DESCRIPTION
This PR adds support for temperature offsets in the set_item_by_id VirtTempOffsetHeat call when the heater is running in auto mode (based on external or internal temperature sensor). 

The value for the service call can be in the range of -7 to 7 so the value parameter was changed in the code from `positive_float` to `float`.

This works fine on a Genus One Net boiler.