### PR TITLE
Fix target temperature step and value

### DIFF
--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -110,7 +110,7 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def target_temperature_step(self) -> float:
         """Return the target temperature step support by the device."""
-        return self.device.get_comfort_temp_step(self.zone)
+        return self.device.get_target_temp_step(self.zone)
 
     @property
     def current_temperature(self) -> float:
@@ -120,7 +120,7 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the target temperature for the device."""
-        return self.device.get_comfort_temp_value(self.zone)
+        return self.device.get_target_temp_value(self.zone)
 
     @property
     def supported_features(self) -> int:


### PR DESCRIPTION
The step and values for target temperature are retrieved from the new exposed methods in the ariston api (require the latest 0.18.0 version).