### PR TITLE
enable current temperature sensor on Evo2

### DIFF
--- a/custom_components/ariston/const.py
+++ b/custom_components/ariston/const.py
@@ -529,6 +529,7 @@ ARISTON_SENSOR_TYPES: list[AristonSensorEntityDescription] = (
         system_types=[SystemType.VELIS],
         whe_types=[
             WheType.Evo,
+            WheType.Evo2,
         ],
     ),
     AristonSensorEntityDescription(


### PR DESCRIPTION
I modified the custom component to display a _Current Temperature_ sensor for my Evo2 boilers a couple of weeks ago. Was there any reason from not having this sensor enabled for this device ? Else maybe we could bring that change upstream ?

`ariston.discover()` returns (amongst other things) `'wheType': 6, 'wheModelType': 22`

Thanks!