### PR TITLE
Add current temperature as a sensor

### DIFF
--- a/custom_components/ariston/const.py
+++ b/custom_components/ariston/const.py
@@ -529,6 +529,7 @@ ARISTON_SENSOR_TYPES: list[AristonSensorEntityDescription] = (
         system_types=[SystemType.VELIS],
         whe_types=[
             WheType.Evo,
+            WheType.NuosSplit,
         ],
     ),
     AristonSensorEntityDescription(


### PR DESCRIPTION
Hello,

This PR implement the current temperature value as sensor for Velis NuosSplit (see #358).

Here is output on the panel:
![Capture d’écran 2024-09-09 à 20 09 50](https://github.com/user-attachments/assets/42e3afcc-8252-4fb2-8933-bcc6ec12ced6)

Hope you can add this if your have time.
Kind regards,
Xavier