### PR TITLE
Remove sets option flow config_entry explicitly, which is deprecated

### DIFF
--- a/custom_components/ariston/config_flow.py
+++ b/custom_components/ariston/config_flow.py
@@ -159,15 +159,11 @@ class AristonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return AristonOptionsFlow(config_entry)
+        return AristonOptionsFlow()
 
 
 class AristonOptionsFlow(config_entries.OptionsFlow):
     """Handle Ariston options."""
-
-    def __init__(self, config_entry) -> None:
-        """Initialize Ariston options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/11/12/options-flow/