### PR TITLE
Fix hvac_action IDLE status for heat pump systems

### DIFF
--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -168,7 +168,7 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     def hvac_action(self):
         """Return the current running hvac operation."""
         if_flame_on = bool(self.device.is_flame_on_value)
-        if_heating_pump_on = bool(self.device.is_heating_pump_on_value)
+        if_heating_pump_on = bool(getattr(self.device, 'is_heating_pump_on_value', False))
 
         if_not_idle = if_flame_on or if_heating_pump_on
 


### PR DESCRIPTION
Heat pumps don't have a flame, so hvac_action was always showing IDLE even when actively heating. Added heating_pump_on check alongside flame_on to correctly detect active heating/cooling for heat pumps while maintaining compatibility with traditional boilers