### PR TITLE
Fix preset mode OFF incorrectly triggers cooling mode

### DIFF
--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -259,6 +259,11 @@ class AristonThermostat(AristonEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
+        _LOGGER.debug(
+            "Setting preset mode to %s for %s",
+            preset_mode,
+            self.name,
+        )
 
         # Don't assume index maps to enum value directly
         preset_index = self.device.plant_mode_opt_texts.index(preset_mode)

--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -259,15 +259,31 @@ class AristonThermostat(AristonEntity, ClimateEntity):
 
     async def async_set_preset_mode(self, preset_mode):
         """Set new target preset mode."""
-        _LOGGER.debug(
-            "Setting preset mode to %s for %s",
-            preset_mode,
-            self.name,
-        )
 
-        await self.device.async_set_plant_mode(
-            PlantMode(self.device.plant_mode_opt_texts.index(preset_mode)),
-        )
+        # Don't assume index maps to enum value directly
+        preset_index = self.device.plant_mode_opt_texts.index(preset_mode)
+        plant_mode = PlantMode(self.device.plant_mode_options[preset_index])
+
+        # Get current states
+        current_plant_in_cool = self.device.is_plant_in_cool_mode
+        zone_modes = self.device.get_zone_mode_options(self.zone)
+
+        # When switching away from cooling mode, ensure zone is in appropriate state
+        if current_plant_in_cool and plant_mode != PlantMode.COOLING:
+            # Set zone to manual heat mode before changing plant mode
+            if ZoneMode.MANUAL in zone_modes:
+                await self.device.async_set_zone_mode(ZoneMode.MANUAL, self.zone)
+
+        # Set the plant mode
+        await self.device.async_set_plant_mode(plant_mode)
+
+        # Special handling for OFF mode
+        if plant_mode == PlantMode.OFF:
+            if self.device.is_zone_mode_options_contains_off(self.zone):
+                await self.device.async_set_zone_mode(BsbZoneMode.OFF, self.zone)
+
+        # Refresh coordinator to get updated device state
+        await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs):


### PR DESCRIPTION
## Problem
Setting climate entity preset to "OFF" causes the heat pump to switch to cooling mode instead of turning off, with error messages appearing in Home Assistant.

## Root Cause
The `async_set_preset_mode()` method incorrectly mapped preset text to `PlantMode` enum by using array index as enum value:
```python
PlantMode(self.device.plant_mode_opt_texts.index(preset_mode))
```
This caused "OFF" at index 3 to map to `PlantMode.COOLING` instead of `PlantMode.OFF`.

## Solution
- Use `plant_mode_options[index]` to get correct `PlantMode` enum value
- Add zone mode handling when switching from cooling mode
- Set zone mode to OFF when plant mode is OFF (if supported)
- Add coordinator refresh for consistent state updates

## Changes
**File:** `custom_components/ariston/climate.py`
- Fixed preset-to-enum conversion in `async_set_preset_mode()`
- Added zone mode coordination for cooling mode transitions
- Added coordinator refresh after mode changes

## Testing
Tested with GALEVO heat pump:
- ✅ Preset "OFF" correctly turns off the system
- ✅ No cooling mode activation
- ✅ No errors in logs
- ✅ Proper state updates