### PR TITLE
feat: Add BSB zone mode support with preset modes and schedule-aware temperature

### DIFF
--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -22,10 +22,10 @@ from .entity import AristonEntity
 _LOGGER = logging.getLogger(__name__)
 
 BSB_ZONE_MODE_TEXTS: dict[int, str] = {
-    0: "Protection",
-    1: "Automatic",
-    2: "Reduced",
-    3: "Comfort",
+    0: "protection",
+    1: "automatic",
+    2: "reduced",
+    3: "comfort",
 }
 
 
@@ -62,6 +62,8 @@ async def async_setup_entry(
 
 class AristonThermostat(AristonEntity, ClimateEntity):
     """Ariston Thermostat Device."""
+
+    _attr_translation_key = "ariston_thermostat"
 
     def __init__(
         self,

--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -72,14 +72,25 @@ class AristonThermostat(AristonEntity, ClimateEntity):
         """Initialize the thermostat."""
         super().__init__(coordinator, description, zone)
 
+    def _get_bsb_zone_mode(self) -> BsbZoneMode:
+        """Get BSB zone mode, working around upstream bug with value 0.
+
+        The upstream library uses `value or BsbZoneMode.UNDEFINED` which
+        treats 0 (Protection/OFF) as falsy, returning UNDEFINED (-1).
+        """
+        try:
+            value = self.device.get_zone(self.zone).get("mode", {}).get("value", None)
+            if value is None:
+                return BsbZoneMode.UNDEFINED
+            return BsbZoneMode(value)
+        except (AttributeError, ValueError):
+            return BsbZoneMode.UNDEFINED
+
     def _is_bsb_reduced_mode(self) -> bool:
         """Check if BSB device is in reduced (manual night) mode."""
         if self.device.plant_mode_supported:
             return False
-        try:
-            return self.device.get_zone_mode(self.zone) == BsbZoneMode.MANUAL_NIGHT
-        except (AttributeError, ValueError):
-            return False
+        return self._get_bsb_zone_mode() == BsbZoneMode.MANUAL_NIGHT
 
     @property
     def name(self) -> str:
@@ -216,11 +227,8 @@ class AristonThermostat(AristonEntity, ClimateEntity):
         if self.device.plant_mode_supported:
             return self.device.plant_mode_text
         # BSB device — map zone mode value to text
-        try:
-            mode = self.device.get_zone_mode(self.zone)
-            return BSB_ZONE_MODE_TEXTS.get(mode.value, str(mode.value))
-        except (AttributeError, ValueError):
-            return None
+        mode = self._get_bsb_zone_mode()
+        return BSB_ZONE_MODE_TEXTS.get(mode.value, str(mode.value))
 
     @property
     def preset_modes(self) -> list[str]:

--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -21,6 +21,13 @@ from .entity import AristonEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+BSB_ZONE_MODE_TEXTS: dict[int, str] = {
+    0: "Protection",
+    1: "Automatic",
+    2: "Reduced",
+    3: "Comfort",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
@@ -65,6 +72,15 @@ class AristonThermostat(AristonEntity, ClimateEntity):
         """Initialize the thermostat."""
         super().__init__(coordinator, description, zone)
 
+    def _is_bsb_reduced_mode(self) -> bool:
+        """Check if BSB device is in reduced (manual night) mode."""
+        if self.device.plant_mode_supported:
+            return False
+        try:
+            return self.device.get_zone_mode(self.zone) == BsbZoneMode.MANUAL_NIGHT
+        except (AttributeError, ValueError):
+            return False
+
     @property
     def name(self) -> str:
         """Return the name of the device."""
@@ -95,16 +111,22 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def min_temp(self):
         """Return minimum temperature."""
+        if self._is_bsb_reduced_mode():
+            return self.device.get_reduced_temp_min(self.zone)
         return self.device.get_comfort_temp_min(self.zone)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
+        if self._is_bsb_reduced_mode():
+            return self.device.get_reduced_temp_max(self.zone)
         return self.device.get_comfort_temp_max(self.zone)
 
     @property
     def target_temperature_step(self) -> float:
         """Return the target temperature step support by the device."""
+        if self._is_bsb_reduced_mode():
+            return self.device.get_reduced_temp_step(self.zone)
         return self.device.get_target_temp_step(self.zone)
 
     @property
@@ -115,6 +137,8 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the target temperature for the device."""
+        if self._is_bsb_reduced_mode():
+            return self.device.get_reduced_temp_value(self.zone)
         return self.device.get_target_temp_value(self.zone)
 
     @property
@@ -125,11 +149,12 @@ class AristonThermostat(AristonEntity, ClimateEntity):
             features |= ClimateEntityFeature.TURN_OFF
         if hasattr(ClimateEntityFeature, "TURN_ON"):
             features |= ClimateEntityFeature.TURN_ON
-        return (
-            features | ClimateEntityFeature.PRESET_MODE
-            if self.device.plant_mode_supported
-            else features
-        )
+        if self.device.plant_mode_supported:
+            features |= ClimateEntityFeature.PRESET_MODE
+        elif not self.device.plant_mode_supported and hasattr(self.device, 'get_zone_mode'):
+            # BSB device — enable preset mode for zone mode selection
+            features |= ClimateEntityFeature.PRESET_MODE
+        return features
 
     @property
     def hvac_mode(self) -> str:
@@ -188,12 +213,26 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., home, away, temp."""
-        return self.device.plant_mode_text
+        if self.device.plant_mode_supported:
+            return self.device.plant_mode_text
+        # BSB device — map zone mode value to text
+        try:
+            mode = self.device.get_zone_mode(self.zone)
+            return BSB_ZONE_MODE_TEXTS.get(mode.value, str(mode.value))
+        except (AttributeError, ValueError):
+            return None
 
     @property
     def preset_modes(self) -> list[str]:
         """Return a list of available preset modes."""
-        return self.device.plant_mode_opt_texts
+        if self.device.plant_mode_supported:
+            return self.device.plant_mode_opt_texts
+        # BSB device — map zone mode options to texts
+        try:
+            options = self.device.get_zone_mode_options(self.zone) or []
+            return [BSB_ZONE_MODE_TEXTS.get(opt, str(opt)) for opt in options]
+        except (AttributeError, ValueError):
+            return []
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
@@ -268,6 +307,16 @@ class AristonThermostat(AristonEntity, ClimateEntity):
             self.name,
         )
 
+        if not self.device.plant_mode_supported:
+            # BSB device — map preset text back to BsbZoneMode
+            options = self.device.get_zone_mode_options(self.zone) or []
+            texts = [BSB_ZONE_MODE_TEXTS.get(opt, str(opt)) for opt in options]
+            idx = texts.index(preset_mode)
+            zone_mode = BsbZoneMode(options[idx])
+            await self.device.async_set_zone_mode(zone_mode, self.zone)
+            self.async_write_ha_state()
+            return
+
         # Don't assume index maps to enum value directly
         preset_index = self.device.plant_mode_opt_texts.index(preset_mode)
         plant_mode = PlantMode(self.device.plant_mode_options[preset_index])
@@ -306,5 +355,8 @@ class AristonThermostat(AristonEntity, ClimateEntity):
             self.name,
         )
 
-        await self.device.async_set_comfort_temp(temperature, self.zone)
+        if self._is_bsb_reduced_mode():
+            await self.device.async_set_reduced_temp(temperature, self.zone)
+        else:
+            await self.device.async_set_comfort_temp(temperature, self.zone)
         self.async_write_ha_state()

--- a/custom_components/ariston/climate.py
+++ b/custom_components/ariston/climate.py
@@ -88,11 +88,21 @@ class AristonThermostat(AristonEntity, ClimateEntity):
         except (AttributeError, ValueError):
             return BsbZoneMode.UNDEFINED
 
-    def _is_bsb_reduced_mode(self) -> bool:
-        """Check if BSB device is in reduced (manual night) mode."""
+    def _is_bsb_currently_reduced(self) -> bool:
+        """Check if BSB device is currently targeting the reduced setpoint.
+
+        Compares desiredRoomTemp against chRedTemp to determine whether the
+        active setpoint is the reduced one. Works for all modes including
+        Automatic (schedule-driven).
+        """
         if self.device.plant_mode_supported:
             return False
-        return self._get_bsb_zone_mode() == BsbZoneMode.MANUAL_NIGHT
+        zone_data = self.device.get_zone(self.zone)
+        desired = zone_data.get("desiredRoomTemp", None)
+        if desired is None:
+            return False
+        reduced = zone_data.get("chRedTemp", {}).get("value", None)
+        return desired == reduced
 
     @property
     def name(self) -> str:
@@ -124,21 +134,21 @@ class AristonThermostat(AristonEntity, ClimateEntity):
     @property
     def min_temp(self):
         """Return minimum temperature."""
-        if self._is_bsb_reduced_mode():
+        if self._is_bsb_currently_reduced():
             return self.device.get_reduced_temp_min(self.zone)
         return self.device.get_comfort_temp_min(self.zone)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        if self._is_bsb_reduced_mode():
+        if self._is_bsb_currently_reduced():
             return self.device.get_reduced_temp_max(self.zone)
         return self.device.get_comfort_temp_max(self.zone)
 
     @property
     def target_temperature_step(self) -> float:
         """Return the target temperature step support by the device."""
-        if self._is_bsb_reduced_mode():
+        if self._is_bsb_currently_reduced():
             return self.device.get_reduced_temp_step(self.zone)
         return self.device.get_target_temp_step(self.zone)
 
@@ -149,9 +159,17 @@ class AristonThermostat(AristonEntity, ClimateEntity):
 
     @property
     def target_temperature(self) -> float:
-        """Return the target temperature for the device."""
-        if self._is_bsb_reduced_mode():
-            return self.device.get_reduced_temp_value(self.zone)
+        """Return the target temperature for the device.
+
+        For BSB devices, use desiredRoomTemp as the source of truth.
+        This reflects the actual active setpoint in all modes, including
+        the schedule-driven setpoint in Automatic mode.
+        """
+        if not self.device.plant_mode_supported:
+            zone_data = self.device.get_zone(self.zone)
+            desired = zone_data.get("desiredRoomTemp", None)
+            if desired is not None:
+                return desired
         return self.device.get_target_temp_value(self.zone)
 
     @property
@@ -365,7 +383,7 @@ class AristonThermostat(AristonEntity, ClimateEntity):
             self.name,
         )
 
-        if self._is_bsb_reduced_mode():
+        if self._is_bsb_currently_reduced():
             await self.device.async_set_reduced_temp(temperature, self.zone)
         else:
             await self.device.async_set_comfort_temp(temperature, self.zone)

--- a/custom_components/ariston/icons.json
+++ b/custom_components/ariston/icons.json
@@ -1,0 +1,19 @@
+{
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:thermostat",
+            "state": {
+              "protection": "mdi:snowflake",
+              "automatic": "mdi:calendar-clock",
+              "reduced": "mdi:moon-waning-crescent",
+              "comfort": "mdi:white-balance-sunny"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ariston/strings.json
+++ b/custom_components/ariston/strings.json
@@ -32,5 +32,21 @@
         }
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/ca.json
+++ b/custom_components/ariston/translations/ca.json
@@ -31,5 +31,21 @@
         "title": "Configura l'Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/de.json
+++ b/custom_components/ariston/translations/de.json
@@ -1,0 +1,52 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "reauth_successful": "Erneute Authentifizierung war erfolgreich"
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Anmeldedaten",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "password": "Passwort",
+          "username": "Benutzername",
+          "api_url_setting": "Ariston API URL",
+          "api_user_agent": "Ariston API User Agent"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "extra_energy_features": "Zusätzliche Energie-Entitäten",
+          "scan_interval": "Zonen-Abfrageintervall (Sekunden)",
+          "energy_scan_interval": "Energie-Abfrageintervall (Minuten)",
+          "bus_errors_scan_interval": "Bus-Fehler-Abfrageintervall (Sekunden)"
+        },
+        "title": "Ariston konfigurieren"
+      }
+    }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Schutzbetrieb",
+              "automatic": "Automatik",
+              "reduced": "Reduziert",
+              "comfort": "Komfort"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ariston/translations/en.json
+++ b/custom_components/ariston/translations/en.json
@@ -32,5 +32,21 @@
         "title": "Configure Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/es.json
+++ b/custom_components/ariston/translations/es.json
@@ -30,5 +30,21 @@
         "title": "Configurar Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/fr.json
+++ b/custom_components/ariston/translations/fr.json
@@ -31,5 +31,21 @@
         "title": "Configurer Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/it.json
+++ b/custom_components/ariston/translations/it.json
@@ -29,5 +29,21 @@
         "title": "Configura Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/pl.json
+++ b/custom_components/ariston/translations/pl.json
@@ -31,5 +31,21 @@
         "title": "Konfiguruj Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/pt.json
+++ b/custom_components/ariston/translations/pt.json
@@ -31,5 +31,21 @@
         "title": "Configurar Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/ru.json
+++ b/custom_components/ariston/translations/ru.json
@@ -29,5 +29,21 @@
         "title": "Настроить Аристон"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ariston/translations/ua.json
+++ b/custom_components/ariston/translations/ua.json
@@ -29,5 +29,21 @@
         "title": "Налаштувати Ariston"
       }
     }
+  },
+  "entity": {
+    "climate": {
+      "ariston_thermostat": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "protection": "Protection",
+              "automatic": "Automatic",
+              "reduced": "Reduced",
+              "comfort": "Comfort"
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Add BSB zone mode and preset support for BSB devices (e.g. Elco Thision S Plus)

### Problem

BSB devices like the Elco Thision S Plus 13 lack proper zone mode support in the
climate entity. The heater supports 4 modes (Protection, Automatic, Reduced, Comfort)
but none of these are exposed in Home Assistant. Additionally, the target temperature
always shows the comfort setpoint, even when the device is in Reduced mode or when
the Automatic schedule is in a reduced period.

There is also a bug in the upstream library where `get_zone_mode()` uses
`value or BsbZoneMode.UNDEFINED`, which treats mode 0 (Protection) as falsy
and returns UNDEFINED (-1).

### Changes

- **BSB zone mode workaround**: Added `_get_bsb_zone_mode()` that reads the raw mode
  value from zone data, working around the upstream `value or UNDEFINED` bug
- **Preset modes for BSB devices**: Exposed Protection, Automatic, Reduced, and Comfort
  as preset modes via `ClimateEntityFeature.PRESET_MODE`
- **Schedule-aware target temperature**: Use `desiredRoomTemp` from the API as the
  source of truth for target temperature display. This correctly reflects the active
  setpoint in all modes, including schedule-driven switching between comfort and
  reduced in Automatic mode
- **Dynamic slider bounds**: Min/max temp and step adapt based on the currently active
  setpoint (comfort vs reduced), determined by comparing `desiredRoomTemp` against
  `chRedTemp`
- **Translations**: Added translatable preset mode names with entity translation keys.
  Includes German translations (`de.json`)
- **Icons**: Added preset mode state icons (snowflake, clock, half-moon, sun)

### Tested on

- Elco Thision S Plus 13 (BSB device)
- Home Assistant 2026.5.4 (Core) on HA Yellow (HAOS)